### PR TITLE
Fixing Tagged Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ package_data = {
         "cornice/+package+/*.*"]}
 
 setup(name='cornice',
-      version='0.16.2tempfix4',
+      version='0.16.2+tempfix4',
       description='Define Web Services in Pyramid.',
       long_description=README + '\n\n' + CHANGES,
       license='MPLv2.0',


### PR DESCRIPTION
This is necessary for newer versions of Python's `setuptools`.